### PR TITLE
Allow disabling markdown route injection

### DIFF
--- a/packages/starlight-contextual-menu/README.md
+++ b/packages/starlight-contextual-menu/README.md
@@ -43,6 +43,11 @@ There are 4 built in actions:
 - `chatgpt`: Open in ChatGPT
 - `claude`: Open in Claude
 
+### Options
+
+- `actions` (default: `['copy', 'view']`)
+- `injectMarkdownRoutes` (default: `true`) — set to `false` if another Starlight integration already adds the markdown routes to avoid duplicate route registration.
+
 By default, when not specifying actions, only `copy` and `view` will appear in the menu.
 
 ## License

--- a/packages/starlight-contextual-menu/index.d.ts
+++ b/packages/starlight-contextual-menu/index.d.ts
@@ -3,7 +3,8 @@ import type { StarlightPlugin } from "@astrojs/starlight/types";
 type ContextualMenuActionType = "copy" | "view" | "claude" | "chatgpt";
 
 export interface StarlightContextualMenuUserConfig {
-  actions: ContextualMenuActionType[];
+  actions?: ContextualMenuActionType[];
+  injectMarkdownRoutes?: boolean;
 }
 
 export default function starlightContextualMenu(

--- a/packages/starlight-contextual-menu/index.js
+++ b/packages/starlight-contextual-menu/index.js
@@ -6,11 +6,14 @@ import { starlightMarkdownIntegration } from "starlight-markdown";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
-function starlightContextualMenuIntegration(options) {
-  const config = {
-    actions: ["copy", "view"], // Default actions
-    ...options,
-  };
+const normalizeConfig = (options = {}) => ({
+  actions: ["copy", "view"],
+  injectMarkdownRoutes: true,
+  ...options,
+});
+
+function starlightContextualMenuIntegration(config) {
+  const normalizedConfig = normalizeConfig(config);
 
   return {
     name: "starlight-contextual-menu",
@@ -26,7 +29,7 @@ function starlightContextualMenuIntegration(options) {
           `
             ${contextualMenuContent};
             initContextualMenu(${JSON.stringify({
-              actions: config.actions,
+              actions: normalizedConfig.actions,
             })});          
           `
         );
@@ -36,12 +39,16 @@ function starlightContextualMenuIntegration(options) {
 }
 
 export default function starlightContextualMenu(userConfig) {
+  const config = normalizeConfig(userConfig);
+
   return {
     name: "starlight-contextual-menu-plugin",
     hooks: {
       "config:setup"({ addIntegration }) {
-        addIntegration(starlightMarkdownIntegration(userConfig));
-        addIntegration(starlightContextualMenuIntegration(userConfig));
+        if (config.injectMarkdownRoutes !== false) {
+          addIntegration(starlightMarkdownIntegration(config));
+        }
+        addIntegration(starlightContextualMenuIntegration(config));
       },
     },
   };


### PR DESCRIPTION
## Summary

- normalize plugin options and introduce an `injectMarkdownRoutes` toggle (default `true`)
- skip calling `starlightMarkdownIntegration` when consumers opt out to avoid duplicate `/index.md` routes
- document the new option in the README and type definitions

## Testing

- `npm run lint` *(not applicable, project has no scripts)*
- `npm pack` *(not run; change is configuration only)*
- Verified `astro dev` no longer emits duplicate route warnings when `injectMarkdownRoutes` is set to `false` in a project that already handles markdown routes, while existing behaviour remains unchanged by default.

Resolves https://github.com/corsfix/starlight-contextual-menu/issues/11.

Footnote: created on behalf of @schickling.
