### PR TITLE
Guard Copy action when ClipboardItem is missing

### DIFF
--- a/packages/starlight-contextual-menu/contextual-menu.js
+++ b/packages/starlight-contextual-menu/contextual-menu.js
@@ -9,21 +9,32 @@ const DEFAULT_ACTIONS = {
         window.location.href.replace(/\/?$/, "/")
       ).toString();
       try {
+        const markdown = await fetch(markdownUrl)
+          .then((response) => {
+            if (!response.ok) {
+              throw new Error(`Received ${response.status} for ${markdownUrl}`);
+            }
+            return response.text();
+          })
+          .catch((error) => {
+            throw new Error(`Received ${error.message} for ${markdownUrl}`);
+          });
+
         /**
          * The MIT License (MIT) Copyright (c) 2021 Cloudflare, Inc.
          * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
          * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
          */
-        const clipboardItem = new ClipboardItem({
-          ["text/plain"]: fetch(markdownUrl)
-            .then((r) => r.text())
-            .then((t) => new Blob([t], { type: "text/plain" }))
-            .catch((e) => {
-              throw new Error(`Received ${e.message} for ${markdownUrl}`);
-            }),
-        });
-
-        await navigator.clipboard.write([clipboardItem]);
+        if (typeof window.ClipboardItem !== "undefined" && navigator.clipboard?.write) {
+          const clipboardItem = new ClipboardItem({
+            ["text/plain"]: new Blob([markdown], { type: "text/plain" }),
+          });
+          await navigator.clipboard.write([clipboardItem]);
+        } else if (navigator.clipboard?.writeText) {
+          await navigator.clipboard.writeText(markdown);
+        } else {
+          throw new Error("Clipboard API is unavailable");
+        }
 
         const buttonElement = document.querySelector(".copy-action");
         const originalContent = buttonElement.innerHTML;


### PR DESCRIPTION
## Summary

- add feature detection before instantiating `ClipboardItem`
- fall back to `navigator.clipboard.writeText` for browsers that do not expose the constructor (e.g. Firefox/Safari)
- keep existing behaviour for browsers that support `ClipboardItem`

## Testing

- Verified the Copy Page button in a local Starlight site on Firefox 130
